### PR TITLE
fix: Partial payload patch

### DIFF
--- a/django_ninja_crudl/__init__.py
+++ b/django_ninja_crudl/__init__.py
@@ -1,7 +1,9 @@
 """Super schema packages."""
 
 from django2pydantic import Infer, ModelFields  # hoisting/bubble up
+
 from django_ninja_crudl.crudl import Crudl, CrudlApiBaseMeta
+from django_ninja_crudl.patch_dict import PatchDict
 from django_ninja_crudl.permissions import BasePermission
 from django_ninja_crudl.types import (
     ObjectlessActions,
@@ -17,6 +19,7 @@ __all__ = [
     "CrudlApiBaseMeta",
     "ObjectlessActions",
     "WithObjectActions",
+    "PatchDict",
     "PathArgs",
     "RequestDetails",
     "BasePermission",

--- a/django_ninja_crudl/crudl.py
+++ b/django_ninja_crudl/crudl.py
@@ -18,7 +18,6 @@ from django.db.models import (
     OneToOneRel,
 )
 from django.http import HttpRequest, HttpResponse
-from ninja import PatchDict
 from ninja_extra import (
     ControllerBase,
     api_controller,
@@ -48,6 +47,7 @@ from django_ninja_crudl.errors.schemas import (
     UnprocessableEntity422Schema,
 )
 from django_ninja_crudl.model_utils import get_pydantic_fields
+from django_ninja_crudl.patch_dict import PatchDict
 from django_ninja_crudl.permissions import BasePermission
 from django_ninja_crudl.types import PathArgs, RequestDetails
 from django_ninja_crudl.utils import add_function_arguments, validating_manager
@@ -125,6 +125,7 @@ class CrudlMeta[TDjangoModel: Model](type):
             raise ValueError(msg)
 
         model_class: type[Model] = meta.model_class
+
 
         api_meta = getattr(model_class, "CrudlApiMeta", meta)
         if api_meta is None:
@@ -595,14 +596,13 @@ class CrudlMeta[TDjangoModel: Model](type):
                     path=update_path,
                     operation_id=patch_operation_id,
                     response={
-                        status.HTTP_200_OK: UpdateSchema,  # pyright: ignore[reportPossiblyUnboundVariable]
+                        status.HTTP_200_OK: PartialUpdateSchema,  # pyright: ignore[reportPossiblyUnboundVariable]
                         status.HTTP_401_UNAUTHORIZED: Unauthorized401Schema,
                         status.HTTP_403_FORBIDDEN: Forbidden403Schema,
                         status.HTTP_404_NOT_FOUND: ResourceNotFound404Schema,
                         status.HTTP_422_UNPROCESSABLE_ENTITY: UnprocessableEntity422Schema,
                         status.HTTP_503_SERVICE_UNAVAILABLE: ServiceUnavailable503Schema,
                     },
-                    exclude_unset=True,
                     by_alias=True,
                 )
                 @transaction.atomic

--- a/django_ninja_crudl/patch_dict.py
+++ b/django_ninja_crudl/patch_dict.py
@@ -1,0 +1,55 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+
+from pydantic_core import core_schema
+from typing_extensions import Annotated
+
+from ninja import Body
+from ninja.utils import is_optional_type
+
+
+class ModelToDict(dict):
+    _wrapped_model: Any = None
+    _wrapped_model_dump_params: Dict[str, Any] = {}
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source: Any, _handler: Any) -> Any:
+        return core_schema.no_info_after_validator_function(
+            cls._validate,
+            cls._wrapped_model.__pydantic_core_schema__,
+        )
+
+    @classmethod
+    def _validate(cls, input_value: Any) -> Any:
+        return input_value.model_dump(**cls._wrapped_model_dump_params)
+
+
+def create_patch_schema(schema_cls: Type[Any]) -> Type[ModelToDict]:
+    values, annotations = {}, {}
+    for f in schema_cls.__fields__.keys():
+        t = schema_cls.__annotations__[f]
+        if not is_optional_type(t):
+            values[f] = getattr(schema_cls, f, None)
+            # 't' should not be annotated as 'Optional'
+            # This is the only difference compared to the original 'patch_dict.py' from 'django-ninja'
+            # https://github.com/vitalik/django-ninja/blob/b1ecd36e1c9b096ca68ca458cce687593d6173af/ninja/patch_dict.py#L32
+            annotations[f] = t
+    values["__annotations__"] = annotations
+    OptionalSchema = type(f"{schema_cls.__name__}Patch", (schema_cls,), values)
+
+    class OptionalDictSchema(ModelToDict):
+        _wrapped_model = OptionalSchema
+        _wrapped_model_dump_params = {"exclude_unset": True}
+
+    return OptionalDictSchema
+
+
+class PatchDictUtil:
+    def __getitem__(self, schema_cls: Any) -> Any:
+        new_cls = create_patch_schema(schema_cls)
+        return Body[new_cls]  # type: ignore
+
+
+if TYPE_CHECKING:  # pragma: nocover
+    PatchDict = Annotated[dict, "<PatchDict>"]
+else:
+    PatchDict = PatchDictUtil()

--- a/django_ninja_crudl/patch_dict.py
+++ b/django_ninja_crudl/patch_dict.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Annotated, Any, Dict, Type
 
 from pydantic_core import core_schema
-from typing_extensions import Annotated
 
 from ninja import Body
 from ninja.utils import is_optional_type


### PR DESCRIPTION
- Cloned `PatchDict` from `django-ninja` with a single small change to make fields in payload optional, but not necessarily nullable
- Use `PartialUpdateSchema` instead of `UpdateSchema`
- Remove `exclude_unset=True` (for now) from `patch` request response as it causes issue with error response

## Summary by Sourcery

Enhance the partial update functionality by introducing a modified 'PatchDict' to make fields optional but not nullable, and replace 'UpdateSchema' with 'PartialUpdateSchema'. Fix an issue with error responses by removing 'exclude_unset=True' from the 'patch' request response.

Bug Fixes:
- Fix issue with error response by removing 'exclude_unset=True' from 'patch' request response.

Enhancements:
- Clone 'PatchDict' from 'django-ninja' with modifications to make fields in payload optional but not nullable.
- Replace 'UpdateSchema' with 'PartialUpdateSchema' for better handling of partial updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `PatchDict` for enhanced handling of partial updates within the CRUDL API.
	- Added a new `ModelToDict` class to facilitate conversion of Pydantic models into dictionaries.
	- Implemented a `create_patch_schema` function for generating new schema classes.

- **Bug Fixes**
	- Improved error handling for integrity and validation errors during object creation and updates.

- **Documentation**
	- Updated public interface to include `PatchDict` for external accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->