### PR TITLE
fix: Trunk permission to create/update label

### DIFF
--- a/.github/workflows/trunk-upgrade-and-check.yml
+++ b/.github/workflows/trunk-upgrade-and-check.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
   trunk-check:
     uses: NextGenContributions/cicd-pipeline/.github/workflows/trunk-check.yml@main


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Added 'issues: write' permission to the GitHub Actions workflow

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `issues: write` permission to the GitHub Actions workflow to allow Trunk to create/update labels.

### Why are these changes being made?

The change is required to grant the necessary permissions for the Trunk process to manage labels, which was previously unauthorized under the current permissions settings. This update ensures that the workflow can perform its label management tasks without issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->