### PR TITLE
chore: Add coveragerc to nitpick config

### DIFF
--- a/.nitpick.toml
+++ b/.nitpick.toml
@@ -1,6 +1,7 @@
 [tool.nitpick]
 style = [
     "github://NextGenContributions/.nitpick@main/nitpick_styles/django-pyproject.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-coveragerc.toml",
     "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-pyre.toml",
     "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-basedpyright.toml",
     "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-codacy.toml",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Added a generic .coveragerc configuration to the Nitpick style imports

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `generic-coveragerc.toml` style to the `.nitpick.toml` configuration file.

### Why are these changes being made?

This change is made to ensure consistent coverage reporting across the project by utilizing a standardized coverage configuration. The addition aligns with existing configurations for other tools, maintaining uniformity in the project's coding standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces a new .coveragerc configuration for Nitpick, standardizing coverage reporting across the project. The change enhances coding standards and ensures consistency in tool usage.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django-ninja-crudl/56)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to include an additional style reference for code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->