### PR TITLE
feat(#63): Unify error responses by using schemas defined by django-ninja-crudl

### DIFF
--- a/django_ninja_crudl/api.py
+++ b/django_ninja_crudl/api.py
@@ -1,11 +1,33 @@
 """Django Ninja CRUDL API."""
 
-from typing import override
+import logging
+import traceback
+from collections.abc import Callable, Sequence
+from typing import Any, override
 
+from django.conf import settings
+from django.http import Http404, HttpRequest, HttpResponse
+from ninja import errors as ninja_exceptions
+from ninja.constants import NOT_SET, NOT_SET_TYPE
+from ninja.openapi.docs import DocsBase, Swagger
 from ninja.openapi.schema import OpenAPISchema
 from ninja.params.models import TModel
-from ninja.types import DictStrAny
-from ninja_extra import NinjaExtraAPI
+from ninja.parser import Parser
+from ninja.renderers import BaseRenderer
+from ninja.throttling import BaseThrottle
+from ninja.types import DictStrAny, TCallable
+from ninja_extra import NinjaExtraAPI, status
+from ninja_extra import exceptions as ninja_extra_exceptions
+
+from django_ninja_crudl.errors.schemas import (
+    Error404NotFoundSchema,
+    Error422UnprocessableEntitySchema,
+    Error500InternalServerErrorSchema,
+    ErrorSchema,
+)
+from django_ninja_crudl.utils import get_request_id
+
+logger = logging.getLogger("django")
 
 
 class NinjaCrudlOpenAPISchema(OpenAPISchema):
@@ -26,6 +48,149 @@ class NinjaCrudlOpenAPISchema(OpenAPISchema):
 
 class NinjaCrudlAPI(NinjaExtraAPI):
     """Ninja Extra API with CRUDL support."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        title: str = "NinjaExtraAPI",
+        version: str = "1.0.0",
+        description: str = "",
+        openapi_url: str | None = "/openapi.json",
+        docs: DocsBase | None = None,
+        docs_url: str | None = "/docs",
+        docs_decorator: Callable[[TCallable], TCallable] | None = None,
+        servers: list[DictStrAny] | None = None,
+        urls_namespace: str | None = None,
+        csrf: bool = False,
+        auth: Sequence[Callable] | Callable | NOT_SET_TYPE | None = NOT_SET,  # type: ignore[type-arg]
+        throttle: BaseThrottle | list[BaseThrottle] | NOT_SET_TYPE = NOT_SET,
+        renderer: BaseRenderer | None = None,
+        parser: Parser | None = None,
+        openapi_extra: dict[str, Any] | None = None,  # pyright: ignore [reportExplicitAny]
+        app_name: str = "ninja",
+        **kwargs: Any,  # noqa: ANN401  # pyright: ignore [reportExplicitAny, reportAny]
+    ) -> None:
+        """Initialize Ninja CRUDL API.
+
+        Args:
+            title: A title for the api.
+            version: The API version.
+            description: A description for the api.
+            openapi_url: The relative URL to serve the openAPI spec.
+            docs: API documentation class.
+            docs_url: The relative URL to serve the API docs.
+            docs_decorator: A decorator for the API docs view.
+            servers: List of target hosts used in openAPI spec.
+            urls_namespace: The Django URL namespace for the API. If not provided,
+                the namespace will be ``"api-" + self.version``.
+            csrf: Require a CSRF token for unsafe request types.
+                See <a href="../csrf">CSRF</a> docs.
+            auth: Authentication class or classes.
+            throttle: Throttling class or list of throttling classes.
+            renderer: Default response renderer.
+            parser: Default request parser.
+            openapi_extra: Additional attributes for the openAPI spec.
+            app_name: The name of the Django app.
+            kwargs: Additional keyword arguments.
+        """
+        if not docs:
+            docs = Swagger()
+
+        super().__init__(  # pyright: ignore [reportUnknownMemberType]
+            title=title,
+            version=version,
+            description=description,
+            openapi_url=openapi_url,
+            docs=docs,
+            docs_url=docs_url,
+            docs_decorator=docs_decorator,
+            servers=servers,
+            urls_namespace=urls_namespace,
+            csrf=csrf,
+            auth=auth,
+            throttle=throttle,
+            renderer=renderer,
+            parser=parser,
+            openapi_extra=openapi_extra,
+            app_name=app_name,
+            **kwargs,
+        )
+
+    @override
+    def set_default_exception_handlers(self) -> None:
+        """Override the default exception handlers set by django-ninja."""
+        self.exception_handler(Exception)(self._default_exception)
+        self.exception_handler(Http404)(self._default_404)
+        self.exception_handler(ninja_exceptions.HttpError)(self._default_http_error)
+        self.exception_handler(ninja_exceptions.ValidationError)(
+            self._default_validation_error
+        )
+
+    @override
+    def api_exception_handler(
+        self, request: HttpRequest, exc: ninja_extra_exceptions.APIException
+    ) -> HttpResponse:
+        """Override and handle generic django-ninja-extra's API exceptions."""
+        headers: dict = {}  # type: ignore[type-arg]
+        if isinstance(exc, ninja_extra_exceptions.Throttled):
+            headers["Retry-After"] = f"{float(exc.wait or 0.0):d}"  # type: ignore[redundant-expr]
+
+        data = ErrorSchema(
+            request_id=get_request_id(request),
+            detail=exc.detail,  # pyright: ignore [reportArgumentType]
+            code=exc.__class__.__name__,
+        )
+        response = self.create_response(request, data, status=exc.status_code)
+        for k, v in headers.items():  # pyright: ignore [reportUnknownVariableType]
+            response.setdefault(k, v)  # pyright: ignore [reportUnknownArgumentType]
+
+        return response
+
+    def _default_404(self, request: HttpRequest, exc: Exception) -> HttpResponse:
+        """Handle Django's 404 errors."""
+        msg = "Not Found"
+        if settings.DEBUG:  # pyright: ignore [reportAny]
+            msg += f": {exc}"
+        data = Error404NotFoundSchema(
+            request_id=get_request_id(request),
+            detail=msg,
+        )
+        return self.create_response(request, data, status=status.HTTP_404_NOT_FOUND)
+
+    def _default_http_error(
+        self, request: HttpRequest, exc: ninja_exceptions.HttpError
+    ) -> HttpResponse:
+        """Handle generic django-ninja HTTP errors."""
+        data = ErrorSchema(
+            request_id=get_request_id(request),
+            detail=str(exc),
+            code=exc.__class__.__name__,
+        )
+        return self.create_response(request, data, status=exc.status_code)
+
+    def _default_validation_error(
+        self, request: HttpRequest, exc: ninja_exceptions.ValidationError
+    ) -> HttpResponse:
+        """Handle django-ninja validation errors."""
+        data = Error422UnprocessableEntitySchema(
+            request_id=get_request_id(request),
+            detail=exc.errors,
+        )
+        return self.create_response(
+            request, data, status=status.HTTP_422_UNPROCESSABLE_ENTITY
+        )
+
+    def _default_exception(self, request: HttpRequest, exc: Exception) -> HttpResponse:
+        """Handle generic server errors."""
+        logger.exception(exc)
+        tb = traceback.format_exc() if settings.DEBUG else None  # pyright: ignore [reportAny]
+        data = Error500InternalServerErrorSchema(
+            request_id=get_request_id(request),
+            detail=tb,
+        )
+        return self.create_response(
+            request, data, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
 
     @override
     def get_openapi_schema(

--- a/django_ninja_crudl/errors/mixin.py
+++ b/django_ninja_crudl/errors/mixin.py
@@ -88,6 +88,4 @@ class ErrorHandlerMixin:
         """Return the 503 error message."""
         response["Retry-After"] = str(self.get_retry_after())
 
-        return 503, Error503ServiceUnavailableSchema(
-            request_id=get_request_id(request)
-        )
+        return 503, Error503ServiceUnavailableSchema(request_id=get_request_id(request))

--- a/django_ninja_crudl/errors/mixin.py
+++ b/django_ninja_crudl/errors/mixin.py
@@ -14,6 +14,7 @@ from django_ninja_crudl.errors.schemas import (
     ErrorSchema,
 )
 from django_ninja_crudl.errors.transform import get_exception_details
+from django_ninja_crudl.utils import get_request_id
 
 
 class ErrorHandlerMixin:
@@ -24,13 +25,6 @@ class ErrorHandlerMixin:
         if type(self) is ErrorHandlerMixin:
             msg = "ErrorHandlerMixin is a mixin and shall not be instantiated directly."
             raise NotImplementedError(msg)
-
-    def get_request_id(self, request: HttpRequest) -> str:
-        """Return the request ID from the request headers.
-
-        You may override this method to get the request ID from a different source.
-        """
-        return request.headers.get("X-Request-ID", "")
 
     def get_retry_after(self) -> int:
         """Return the number of seconds to wait before retrying the request.
@@ -46,7 +40,7 @@ class ErrorHandlerMixin:
         exception: Exception | None = None,  # NOSONAR  # noqa: ARG002
     ) -> tuple[Literal[401], ErrorSchema]:
         """Return the 401 error message."""
-        return 401, Error401UnauthorizedSchema(request_id=self.get_request_id(request))
+        return 401, Error401UnauthorizedSchema(request_id=get_request_id(request))
 
     def get_403_error(
         self,
@@ -55,7 +49,7 @@ class ErrorHandlerMixin:
         exception: Exception | None = None,  # NOSONAR  # noqa: ARG002
     ) -> tuple[Literal[403], Error403ForbiddenSchema]:
         """Return the 403 error message."""
-        return 403, Error403ForbiddenSchema(request_id=self.get_request_id(request))
+        return 403, Error403ForbiddenSchema(request_id=get_request_id(request))
 
     def get_404_error(
         self,
@@ -64,7 +58,7 @@ class ErrorHandlerMixin:
         exception: Exception | None = None,  # NOSONAR  # noqa: ARG002
     ) -> tuple[Literal[404], ErrorSchema]:
         """Return the 404 error message."""
-        return 404, Error404NotFoundSchema(request_id=self.get_request_id(request))
+        return 404, Error404NotFoundSchema(request_id=get_request_id(request))
 
     def get_409_error(
         self,
@@ -81,8 +75,8 @@ class ErrorHandlerMixin:
             traceback.print_exc()
 
         return 409, Error409ConflictSchema(
-            request_id=self.get_request_id(request),
-            details=get_exception_details(exception),
+            request_id=get_request_id(request),
+            detail=get_exception_details(exception),
         )
 
     def get_503_error(
@@ -95,5 +89,5 @@ class ErrorHandlerMixin:
         response["Retry-After"] = str(self.get_retry_after())
 
         return 503, Error503ServiceUnavailableSchema(
-            request_id=self.get_request_id(request)
+            request_id=get_request_id(request)
         )

--- a/django_ninja_crudl/errors/schemas.py
+++ b/django_ninja_crudl/errors/schemas.py
@@ -23,7 +23,7 @@ class ErrorSchema(BaseModel):
     message: str = ""
     user_friendly_message: str = ""
     request_id: str = ""
-    details: str | list[DictStrAny] | None = None
+    detail: str | list[DictStrAny] | None = None
 
 
 class Error401UnauthorizedSchema(ErrorSchema):
@@ -89,6 +89,17 @@ class Error429TooManyRequestSchema(ErrorSchema):
     user_friendly_message: str = _(
         "You have exceeded the rate limit. You can try again in a few minutes."
     )
+
+
+class Error500InternalServerErrorSchema(ErrorSchema):
+    """The default service unavailable schema."""
+
+    code: str = "InternalServerError"
+    message: str = (
+        "The server encountered an unexpected condition "
+        "that prevented it from fulfilling the request."
+    )
+    user_friendly_message: str = _("The server encountered an unexpected condition.")
 
 
 class Error503ServiceUnavailableSchema(ErrorSchema):

--- a/django_ninja_crudl/utils.py
+++ b/django_ninja_crudl/utils.py
@@ -9,6 +9,7 @@ from typing import Any, final
 from beartype import beartype
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.db.models import Field, ForeignObjectRel
+from django.http import HttpRequest
 from django2pydantic import BaseSchema
 from django2pydantic.schema import SchemaConfig
 from ninja import Path
@@ -122,3 +123,8 @@ def validating_manager(model_class: type[TDjangoModel]) -> Generator[None, None,
         yield
     finally:
         model_class.save = original_save
+
+
+def get_request_id(request: HttpRequest) -> str:
+    """Return the request ID from the request headers."""
+    return request.headers.get("X-Request-ID", "")

--- a/tests/test_django/urls.py
+++ b/tests/test_django/urls.py
@@ -48,7 +48,7 @@ class HasResourcePermissions(BasePermission[TDjangoModel]):
     @override
     def has_permission(self, request: RequestDetails[TDjangoModel]) -> bool:
         """Check if the user has permission to perform the action."""
-        user = cast(User, request.request.user)
+        user = cast("User", request.request.user)
 
         if user.username in [ADMIN_USER, STANDARD_USER]:  # pyright: ignore [reportUnknownMemberType]
             return True
@@ -58,7 +58,7 @@ class HasResourcePermissions(BasePermission[TDjangoModel]):
     @override
     def has_object_permission(self, request: RequestDetails[TDjangoModel]) -> bool:
         """Check if the user has permission to perform the action on the object."""
-        user = cast(User, request.request.user)
+        user = cast("User", request.request.user)
 
         if user.username == ADMIN_USER:  # pyright: ignore [reportUnknownMemberType]
             return True
@@ -66,7 +66,7 @@ class HasResourcePermissions(BasePermission[TDjangoModel]):
         if user.username == STANDARD_USER:  # pyright: ignore [reportUnknownMemberType]
             # Check if the user is the owner of the object
             if request.object and hasattr(request.object, "created_by"):
-                obj = cast(BaseModel, request.object)
+                obj = cast("BaseModel", request.object)
                 return obj.created_by == user  # pyright: ignore [reportUnknownVariableType, reportUnknownMemberType]
 
         return False
@@ -76,7 +76,7 @@ class HasResourcePermissions(BasePermission[TDjangoModel]):
         self, request: RequestDetails[TDjangoModel]
     ) -> bool:
         """Check if the user has permission to perform the action on related object."""
-        user = cast(User, request.request.user)
+        user = cast("User", request.request.user)
 
         if user.username == ADMIN_USER:  # pyright: ignore [reportUnknownMemberType]
             return True
@@ -84,7 +84,7 @@ class HasResourcePermissions(BasePermission[TDjangoModel]):
         if user.username == STANDARD_USER:  # pyright: ignore [reportUnknownMemberType]
             # Check if the user is the owner of the object
             if request.related_object and hasattr(request.related_object, "created_by"):
-                obj = cast(BaseModel, request.related_object)
+                obj = cast("BaseModel", request.related_object)
                 return obj.created_by == user  # pyright: ignore [reportUnknownVariableType, reportUnknownMemberType]
 
         return False
@@ -143,7 +143,7 @@ class GatedAuthorCrudl(CrudlController[Author], DefaultFilter[Author]):  # pylin
     @override
     def get_filter_for_list(self, request: RequestDetails[TDjangoModel]) -> Q:
         """Return the queryset filter that applies to the list operation."""
-        user = cast(User, request.request.user)
+        user = cast("User", request.request.user)
 
         if user.username == ADMIN_USER:  # pyright: ignore [reportUnknownMemberType]
             return Q()

--- a/tests/test_error_schemas.py
+++ b/tests/test_error_schemas.py
@@ -131,9 +131,9 @@ def test_http_500_with_debug_off_conforms_with_crudl_error_schema(
 ) -> None:
     """Test server error when DEBUG is OFF."""
     response = get_author_with_mock_internal_server_error(client)
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
-        response.json()
-    )
+    assert (
+        response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    ), response.json()
     Error500InternalServerErrorSchema.model_validate(response.json())
     assert response.json()["detail"] is None
 
@@ -145,8 +145,8 @@ def test_http_500_with_debug_on_conforms_with_crudl_error_schema(
 ) -> None:
     """Test server error when DEBUG is ON."""
     response = get_author_with_mock_internal_server_error(client)
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
-        response.json()
-    )
+    assert (
+        response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    ), response.json()
     Error500InternalServerErrorSchema.model_validate(response.json())
     assert response.json()["detail"] is not None

--- a/tests/test_error_schemas.py
+++ b/tests/test_error_schemas.py
@@ -1,0 +1,152 @@
+"""Test errors in the API."""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client, override_settings
+from ninja_extra import status
+
+from django_ninja_crudl.errors.schemas import (
+    Error401UnauthorizedSchema,
+    Error403ForbiddenSchema,
+    Error404NotFoundSchema,
+    Error409ConflictSchema,
+    Error422UnprocessableEntitySchema,
+    Error500InternalServerErrorSchema,
+)
+from tests.test_django.app import models
+from tests.test_django.urls import RESTRICTED_USER
+
+
+@pytest.mark.django_db
+def test_http_401_conforms_with_crudl_error_schema(client: Client) -> None:
+    """Test getting a resource with GET request."""
+    author = models.Author.objects.create(
+        name="Some author",
+        birth_date="1990-01-01",
+    )
+    response = client.get(
+        f"/api/gated-authors/{author.id}",
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
+    Error401UnauthorizedSchema.model_validate(response.json())
+
+
+@pytest.mark.django_db
+def test_http_403_conforms_with_crudl_error_schema(client: Client) -> None:
+    """Test getting a resource with GET request."""
+    author = models.Author.objects.create(
+        name="Some author",
+        birth_date="1990-01-01",
+    )
+    u = User.objects.create_user(RESTRICTED_USER)
+    client.force_login(u)
+    response = client.get(
+        f"/api/gated-authors/{author.id}",
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+    Error403ForbiddenSchema.model_validate(response.json())
+
+
+@pytest.mark.django_db
+def test_http_404_conforms_with_crudl_error_schema(client: Client) -> None:
+    """Test getting a resource with GET request."""
+    response = client.get(
+        "/api/authors/1",
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    Error404NotFoundSchema.model_validate(response.json())
+
+
+@pytest.mark.django_db
+def test_http_409_conforms_with_crudl_error_schema(client: Client) -> None:
+    """Test creating a resource with POST request."""
+    publisher = models.Publisher.objects.create(
+        name="Some publisher",
+        address="Some address",
+    )
+    author = models.Author.objects.create(
+        name="Some author",
+        birth_date="1990-01-01",
+    )
+    _ = models.Book.objects.create(
+        title="Some book",
+        isbn="9783161484100",
+        publication_date="2021-01-01",
+        publisher=publisher,
+    )
+
+    response = client.post(
+        "/api/books",
+        content_type="application/json",
+        data={
+            "title": "Some new book",
+            "isbn": "9783161484100",
+            "publication_date": "2022-01-01",
+            "publisher_id": publisher.id,
+            "authors": [author.id],
+        },
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT, response.json()
+    assert response.json()["detail"][0]["msg"] == "Book with this Isbn already exists."
+    Error409ConflictSchema.model_validate(response.json())
+
+
+@pytest.mark.django_db
+def test_http_422_conforms_with_crudl_error_schema(client: Client) -> None:
+    """Test updating a resource with POST request."""
+    response = client.post(
+        "/api/authors",
+        content_type="application/json",
+        data={
+            "bad_name": "Some author",
+        },
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.json()
+    assert response.json()["detail"][0]["msg"] == "Field required"
+    assert response.json()["detail"][0]["loc"] == ["body", "payload", "name"]
+    Error422UnprocessableEntitySchema.model_validate(response.json())
+
+
+def get_author_with_mock_internal_server_error(client: Client):  # type: ignore[no-untyped-def]  # noqa: ANN201
+    """Get an author with mocked internal server error."""
+    with patch(
+        "django_ninja_crudl.errors.mixin.ErrorHandlerMixin.get_404_error",
+        side_effect=Exception("Internal Server Error"),
+    ):
+        return client.get(
+            "/api/authors/1",
+            content_type="application/json",
+        )
+
+
+@override_settings(DEBUG=False)
+@pytest.mark.django_db
+def test_http_500_with_debug_off_conforms_with_crudl_error_schema(
+    client: Client,
+) -> None:
+    """Test server error when DEBUG is OFF."""
+    response = get_author_with_mock_internal_server_error(client)
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
+        response.json()
+    )
+    Error500InternalServerErrorSchema.model_validate(response.json())
+    assert response.json()["detail"] is None
+
+
+@override_settings(DEBUG=True)
+@pytest.mark.django_db
+def test_http_500_with_debug_on_conforms_with_crudl_error_schema(
+    client: Client,
+) -> None:
+    """Test server error when DEBUG is ON."""
+    response = get_author_with_mock_internal_server_error(client)
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
+        response.json()
+    )
+    Error500InternalServerErrorSchema.model_validate(response.json())
+    assert response.json()["detail"] is not None


### PR DESCRIPTION
Fix #63 

## Summary by Sourcery

Use django-ninja-crudl error schemas to standardize all API error responses, register custom exception handlers in NinjaCrudlAPI, and consolidate request ID extraction.

New Features:
- Add custom exception handlers in NinjaCrudlAPI to return standardized error schemas for 404, 422, 500, and other errors.
- Include a request ID in all error responses by introducing a get_request_id utility function.

Enhancements:
- Refactor ErrorHandlerMixin to use the centralized get_request_id utility and update ErrorSchema field from details to detail.
- Define a new Error500InternalServerErrorSchema with appropriate default messages and codes.

Tests:
- Add integration tests to verify 401, 403, 404, 409, 422, and 500 error responses conform to the new schemas under both DEBUG modes. 
 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django-ninja-crudl/64)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API class with enhanced and standardized error handling for CRUDL operations, providing structured error responses with request IDs and user-friendly messages.
  - Added a dedicated error schema for internal server errors (500).

- **Bug Fixes**
  - Improved consistency in error response field naming.

- **Refactor**
  - Centralized request ID extraction into a utility function for easier reuse and maintenance.
  - Updated error schemas and mixins to align with new error response structure.

- **Tests**
  - Added comprehensive tests to ensure all HTTP error responses conform to their respective error schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances error handling in the Django Ninja CRUDL API by standardizing and unifying error responses with predefined schemas, improving clarity and consistency. It introduces custom exception handlers for various HTTP error codes, integrates a utility for extracting request IDs, and refactors type casting in test files for better compatibility. Additionally, new tests ensure compliance with the defined error schemas and align with the new error response structure.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>