### PR TITLE
fix: list endpoint support for model's property and related fields

### DIFF
--- a/django_ninja_crudl/endpoints/list.py
+++ b/django_ninja_crudl/endpoints/list.py
@@ -4,12 +4,7 @@ import logging
 from abc import ABC
 from typing import TYPE_CHECKING, Literal, Unpack
 
-from django.db import models
-from django.db.models import (
-    ForeignKey,
-    OneToOneField,
-    OneToOneRel,
-)
+from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from ninja_extra import http_get, status
 
@@ -22,14 +17,12 @@ from django_ninja_crudl.errors.schemas import (
     Error503ServiceUnavailableSchema,
     ErrorSchema,
 )
-from django_ninja_crudl.model_utils import get_pydantic_fields
 from django_ninja_crudl.types import (
     RequestDetails,
     RequestParams,
     TDjangoModel,
 )
 from django_ninja_crudl.utils import (
-    get_model_field,
     replace_path_args_annotation,
 )
 
@@ -68,7 +61,9 @@ def get_get_many_endpoint(config: CrudlConfig[TDjangoModel]) -> type | None:
             request: HttpRequest,
             response: HttpResponse,
             **kwargs: Unpack[RequestParams],
-        ) -> tuple[Literal[401, 403], ErrorSchema] | models.Manager[TDjangoModel]:
+        ) -> (
+            tuple[Literal[401, 403], ErrorSchema] | QuerySet[TDjangoModel, TDjangoModel]
+        ):
             """List all objects."""
             request_details = RequestDetails[TDjangoModel](
                 action="list",
@@ -90,96 +85,127 @@ def get_get_many_endpoint(config: CrudlConfig[TDjangoModel]) -> type | None:
 
             # Return the total count of objects in the response headers
             response["x-total-count"] = qs.count()
-
-            # Extract the related models from the ListSchema fields
-            related_models: list[str] = []
-            many_to_many_models: list[str] = []
-            related_fields: list[str] = []
-            property_fields: list[str] = []
-            m2m_fields: list[str] = []
-
-            for field_name in list_schema.model_fields:
-                attr = getattr(config.model, field_name, None)  # noqa: WPS220
-
-                # Skip @property methods here
-                if attr and isinstance(attr, property):
-                    property_fields.append(field_name)  # noqa: WPS220
-                    # TODO: Implement a way to avoid N+1 queries when using @property methods
-                    logger.debug(  # noqa: WPS220
-                        "Detected use of @property method %s of the model %s in"
-                        " list_fields definition which"
-                        " may cause N+1 queries and cause performance degradation.",
-                        field_name,
-                        config.model,
-                    )
-                    return qs  # noqa: WPS220
-
-                django_field = get_model_field(config.model, field_name)
-                if type(django_field) in {
-                    ForeignKey,
-                    OneToOneField,
-                    OneToOneRel,
-                }:
-                    related_models.append(field_name)  # noqa: WPS220
-                    related_fields.extend(  # noqa: WPS220
-                        get_pydantic_fields(
-                            list_schema,
-                            field_name,
-                        ),
-                    )
-
-                elif type(django_field) in {
-                    models.ManyToManyField,
-                    models.ManyToManyRel,
-                    models.ManyToOneRel,
-                }:
-                    many_to_many_models.append(field_name)  # noqa: WPS220
-                    m2m_fields.extend(  # noqa: WPS220
-                        get_pydantic_fields(
-                            list_schema,
-                            field_name,
-                        ),
-                    )
-                    # related_models.append(f"{field_name}__id")
-
-            non_related_fields: list[str] = [
-                field_name
-                for field_name in list_schema.model_fields.keys()
-                if field_name
-                # not in related_models + many_to_many_models + property_fields
-                not in related_models + many_to_many_models + property_fields
-            ]
-
-            all_fields: list[str] = non_related_fields + related_fields
-
-            qs = qs.select_related(*related_models).prefetch_related(
-                *many_to_many_models,
-            )  # To avoid N+1 queries
-            qs = qs.values(*all_fields)
-
-            # TODO(phuongfi91): find alternative to this janky solution
+            # TODO(phuongfi91): support pagination
+            #  https://github.com/NextGenContributions/django-ninja-crudl/issues/34
+            # TODO(phuongfi91): optimize the query
             #  https://github.com/NextGenContributions/django-ninja-crudl/issues/35
-            # add m2m fields (with supported structure) to the response
-            l = list(qs)
-            for i in l:
-                for m in many_to_many_models:
-                    from django.db.models import F
+            return qs
 
-                    relevant_m2m_fields = list(
-                        filter(lambda x: x.startswith(m), m2m_fields)
-                    )
-                    m2m_values = (
-                        config.model._default_manager.filter(id=i["id"])
-                        .values(*relevant_m2m_fields)
-                        .values(
-                            **{
-                                f.removeprefix(f"{m}__"): F(f)
-                                for f in relevant_m2m_fields
-                            }
-                        )
-                    )
-                    i[m] = list(m2m_values)
-
-            return l
+            # The following code are extremely janky and won't be used for now
+            ############################################################
+            # # Extract the related models from the ListSchema fields
+            # related_models: list[str] = []
+            # many_to_many_models: list[str] = []
+            # related_fields: list[str] = []
+            # property_fields: list[str] = []
+            # m2m_fields: list[str] = []
+            #
+            # for field_name in list_schema.model_fields:
+            #     attr = getattr(config.model, field_name, None)  # noqa: WPS220
+            #
+            #     # Skip @property methods here
+            #     if attr and isinstance(attr, property):
+            #         property_fields.append(field_name)  # noqa: WPS220
+            #         # TODO(jhassine): Implement a way to avoid N+1 queries when using @property methods
+            #         logger.debug(  # noqa: WPS220
+            #             "Detected use of @property method %s of the model %s in"
+            #             " list_fields definition which"
+            #             " may cause N+1 queries and cause performance degradation.",
+            #             field_name,
+            #             config.model,
+            #         )
+            #         continue
+            #         # return qs  # noqa: WPS220
+            #
+            #     django_field = get_model_field(config.model, field_name)
+            #     if type(django_field) in {
+            #         ForeignKey,
+            #         OneToOneField,
+            #         OneToOneRel,
+            #     }:
+            #         related_models.append(field_name)  # noqa: WPS220
+            #         related_fields.extend(  # noqa: WPS220
+            #             set(
+            #                 [f"{field_name}__pk"]
+            #                 + get_pydantic_fields(
+            #                     list_schema,
+            #                     field_name,
+            #                 )
+            #             ),
+            #         )
+            #
+            #     elif type(django_field) in {
+            #         models.ManyToManyField,
+            #         models.ManyToManyRel,
+            #         models.ManyToOneRel,
+            #     }:
+            #         many_to_many_models.append(field_name)  # noqa: WPS220
+            #         m2m_fields.extend(  # noqa: WPS220
+            #             get_pydantic_fields(
+            #                 list_schema,
+            #                 field_name,
+            #             ),
+            #         )
+            #
+            # non_related_fields: list[str] = [
+            #     field_name
+            #     for field_name in list_schema.model_fields.keys()
+            #     if field_name
+            #     not in related_models + many_to_many_models + property_fields
+            # ]
+            #
+            # # TODO(phuongfi91): support returning property fields
+            # #  https://github.com/NextGenContributions/django-ninja-crudl/issues/35
+            # all_fields: list[str] = non_related_fields + related_fields
+            #
+            # qs = qs.select_related(*related_models).prefetch_related(
+            #     *many_to_many_models,
+            # )  # To avoid N+1 queries
+            # qs = qs.values(*all_fields)
+            #
+            # # TODO(phuongfi91): find alternative to this janky solution
+            # #  https://github.com/NextGenContributions/django-ninja-crudl/issues/35
+            # # add m2m fields (with supported structure) to the response
+            # l = cast("list[dict[str, Any]]", list(qs))  # pyright: ignore [reportExplicitAny]
+            # for i in l:
+            #     for r in related_models:
+            #         if i[f"{r}__pk"] is None:
+            #             # remove all related fields if the related model is doesn't exist
+            #             keys_to_remove = [f for f in i.keys() if f.startswith(f"{r}__")]
+            #             for k in keys_to_remove:
+            #                 _ = i.pop(k, None)  # pyright: ignore [reportAny]
+            #         elif f"{r}__pk" not in get_pydantic_fields(list_schema, r):
+            #             # only remove related field pk if it wasn't explicitly requested in the schema
+            #             _ = i.pop(f"{r}__pk", None)  # pyright: ignore [reportAny]
+            #
+            #     for m in many_to_many_models:
+            #         from django.db.models import F
+            #
+            #         relevant_m2m_fields = set(
+            #             [f"{m}__pk"]
+            #             + list(filter(lambda x: x.startswith(m), m2m_fields))
+            #         )
+            #         m2m_values = list(
+            #             config.model._default_manager.filter(id=i["id"])
+            #             .values(*relevant_m2m_fields)
+            #             .values(
+            #                 **{
+            #                     f.removeprefix(f"{m}__"): F(f)
+            #                     for f in relevant_m2m_fields
+            #                 }
+            #             )
+            #         )
+            #
+            #         # only keep m2m values that are not None
+            #         m2m_values = [v for v in m2m_values if v["pk"] is not None]
+            #
+            #         # remove m2m field pk if it wasn't explicitly requested in the schema
+            #         if f"{m}__pk" not in get_pydantic_fields(list_schema, m):
+            #             for v in m2m_values:
+            #                 _ = v.pop("pk", None)  # pyright: ignore [reportAny]
+            #
+            #         i[m] = m2m_values
+            #
+            # return l
 
     return GetManyEndpoint

--- a/tests/test_django/urls.py
+++ b/tests/test_django/urls.py
@@ -239,6 +239,7 @@ class AuthorCrudl(CrudlController[Author], DefaultFilter[Author]):  # pylint: di
                 "books_count": Infer,
                 "books": {"id": Infer, "title": Infer},
                 "amazon_author_profile": {"description": Infer},
+                "user": {"first_name": Infer, "last_name": Infer},
             }
         ),
         list_schema=Schema[Author](
@@ -250,6 +251,7 @@ class AuthorCrudl(CrudlController[Author], DefaultFilter[Author]):  # pylint: di
                 "books_count": Infer,
                 "books": {"id": Infer, "title": Infer},
                 "amazon_author_profile": {"description": Infer},
+                "user": {"first_name": Infer, "last_name": Infer},
             }
         ),
         delete_allowed=True,

--- a/tests/test_reverse_one_to_one_relation_crudl_operations_are_supported.py
+++ b/tests/test_reverse_one_to_one_relation_crudl_operations_are_supported.py
@@ -156,6 +156,9 @@ def test_getting_relation_with_get_many_should_work(client: Client) -> None:
     assert (
         response.json()[0]["amazon_author_profile"]["description"] == "Some description"
     )
+    assert response.json()[0]["user"] is None
+    assert response.json()[0]["age"] == 35
+    assert response.json()[0]["books_count"] == 0
 
 
 @pytest.mark.django_db
@@ -174,3 +177,6 @@ def test_getting_relation_with_get_one_should_work(client: Client) -> None:
     assert response.json()["name"] == "Some author"
     assert response.json()["birth_date"] == "1990-01-01"
     assert response.json()["amazon_author_profile"]["description"] == "Some description"
+    assert response.json()["age"] == 35
+    assert response.json()["books_count"] == 0
+    assert response.json()["user"] is None


### PR DESCRIPTION
Makeshift fix for issues with list endpoint:
- Model's property isn't supported
- Related field values are incorrectly returned when it's `None`

## Summary by Sourcery

Fix the list endpoint to properly return model properties and null-related fields without custom value transformations by simplifying it to return a raw QuerySet

Bug Fixes:
- Restore support for @property fields and ensure related fields are returned as null when missing

Enhancements:
- Simplify list endpoint by removing manual related and property field extraction and returning a QuerySet directly

Tests:
- Add assertions in list and get-one tests for null reverse OneToOne relations and property-derived fields

Chores:
- Include 'user' field in list and read schemas to expose relation in API

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django-ninja-crudl/71)
<!-- Reviewable:end -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the list endpoint functionality in the django_ninja_crudl framework by improving the handling of model properties and related fields, addressing performance issues, and introducing a new user field in the author schema. These changes aim to optimize data retrieval and ensure accuracy in the response.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are well-defined and include tests, making the review process straightforward.
</div>