### PR TITLE
fix: Test runs with nox should respect uv.lock deps

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,17 @@ nox.options.default_venv_backend = "uv"
 @nox.parametrize("django_version", ["5.1", "5.2"])
 def tests(session: nox.Session, django_version: str) -> None:
     """Run the test suite."""
-    session.install(".", f"django=={django_version}", "--group", "tests")
+    # https://nox.thea.codes/en/stable/cookbook.html#using-a-lockfile
+    session.run_install(
+        "uv",
+        "sync",
+        "--no-dev",
+        "--group=tests",
+        f"--python={session.virtualenv.location}",
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+    )
+    # Override django version from lockfile
+    session.install(f"django=={django_version}")
     session.run("pytest", "-vv")
 
 


### PR DESCRIPTION
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Tests:
- Update nox test session to install packages via ‘uv sync’ against uv.lock with --no-dev and --group=tests and then install the specified Django version 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug by updating the Nox configuration to respect lockfile dependencies. It replaces direct package installations with synchronized installations using 'uv sync' and overrides the Django version while configuring UV environment variables.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django-ninja-crudl/187)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test environment setup to use a lockfile-aware sync followed by an explicit Django version installation, improving consistency and aligning dependencies for test runs.
  - Preserves existing test execution with pytest.

- **Chores**
  - Refined virtual environment handling by ensuring the test environment path is correctly propagated during setup.
  - Improved dependency resolution flow during test initialization, reducing mismatches and clarifying error ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->